### PR TITLE
fix: use lwc.config.json

### DIFF
--- a/lwc.config.json
+++ b/lwc.config.json
@@ -1,0 +1,8 @@
+{
+    "modules": [
+      {
+        "dir": "src/modules"
+      }
+    ]
+  }
+  

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -5,9 +5,6 @@ import lwc from "vite-plugin-lwc";
 // https://vitejs.dev/config
 export default defineConfig({
   plugins: [
-        lwc({
-                modules: [{ dir: 'src/modules' }],
-                include: /src\/modules/
-        }),
+    lwc()
   ]
 });


### PR DESCRIPTION
The fix here is actually removing the "include", so you can use the vite config below instead of `lwc.config.json` if you prefer:

```typescript
import { defineConfig } from 'vite';

import lwc from "vite-plugin-lwc";

// https://vitejs.dev/config
export default defineConfig({
  plugins: [
    lwc({
      modules: [
        {
          dir: "src/modules",
        }
      ]
    })
  ]
});